### PR TITLE
Allow setting EditorPlugins state via set_plugin_state and get_plugin_state

### DIFF
--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -283,6 +283,22 @@ bool EditorInterface::is_plugin_enabled(const String &p_plugin) const {
 	return EditorNode::get_singleton()->is_addon_plugin_enabled(p_plugin);
 }
 
+void EditorInterface::set_plugin_state(const String &p_plugin, const Dictionary &p_state) {
+	EditorPlugin *plugin = EditorNode::get_singleton()->get_editor_data().get_editor(p_plugin);
+	if (plugin) {
+		plugin->set_state(p_state);
+	}
+}
+
+Dictionary EditorInterface::get_plugin_state(const String &p_plugin) const {
+	EditorPlugin *plugin = EditorNode::get_singleton()->get_editor_data().get_editor(p_plugin);
+	if (plugin) {
+		return plugin->get_state();
+	} else {
+		return Dictionary();
+	}
+}
+
 EditorInspector *EditorInterface::get_inspector() const {
 	return EditorNode::get_singleton()->get_inspector();
 }
@@ -344,6 +360,9 @@ void EditorInterface::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_plugin_enabled", "plugin", "enabled"), &EditorInterface::set_plugin_enabled);
 	ClassDB::bind_method(D_METHOD("is_plugin_enabled", "plugin"), &EditorInterface::is_plugin_enabled);
+	
+	ClassDB::bind_method(D_METHOD("set_plugin_state", "plugin", "state"), &EditorInterface::set_plugin_state);
+	ClassDB::bind_method(D_METHOD("get_plugin_state", "plugin"), &EditorInterface::get_plugin_state);
 
 	ClassDB::bind_method(D_METHOD("get_inspector"), &EditorInterface::get_inspector);
 

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -106,6 +106,9 @@ public:
 	void set_plugin_enabled(const String &p_plugin, bool p_enabled);
 	bool is_plugin_enabled(const String &p_plugin) const;
 
+	void set_plugin_state(const String &p_plugin, const Dictionary &p_state);
+	Dictionary get_plugin_state(const String &p_plugin) const;
+
 	EditorInspector *get_inspector() const;
 
 	Error save_scene();


### PR DESCRIPTION
Add `set_plugin_state` and `get_plugin_state`.

This allows us to do things like:

```
var editor_state = _ei.get_plugin_state("3D")
var first_viewport = editor_state["viewports"][0]
first_viewport["y_rotation"] = Consts.ISO_CAMERA_ROT_Y_RAD 
```