### PR TITLE
Added particle spawn order options when using points textures

### DIFF
--- a/doc/classes/ParticlesMaterial.xml
+++ b/doc/classes/ParticlesMaterial.xml
@@ -147,6 +147,9 @@
 		<member name="emission_point_texture" type="Texture" setter="set_emission_point_texture" getter="get_emission_point_texture">
 			Particles will be emitted at positions determined by sampling this texture at a random position. Used with [constant EMISSION_SHAPE_POINTS] and [constant EMISSION_SHAPE_DIRECTED_POINTS]. Can be created automatically from mesh or node by selecting "Create Emission Points from Mesh/Node" under the "Particles" tool in the toolbar.
 		</member>
+		<member name="emission_points_order" type="int" setter="set_emission_point_order" getter="get_emission_point_order" enum="ParticlesMaterial.PointsOrder">
+			The order in which points are read from the texture. Can be random, normal and reverse.
+		</member>
 		<member name="emission_ring_axis" type="Vector3" setter="set_emission_ring_axis" getter="get_emission_ring_axis">
 			The axis of the ring when using the emitter [constant EMISSION_SHAPE_RING].
 		</member>
@@ -329,6 +332,18 @@
 		</constant>
 		<constant name="EMISSION_SHAPE_MAX" value="6" enum="EmissionShape">
 			Represents the size of the [enum EmissionShape] enum.
+		</constant>
+		<constant name="EMISSION_POINTS_ORDER_RANDOM" value="0" enum="PointsOrder">
+			Particles from point textures will be emitted with a random order.
+		</constant>
+		<constant name="EMISSION_POINTS_ORDER_NORMAL" value="1" enum="PointsOrder">
+			Particles from points texture will emit in the order in which they are stored in the  [member emission_points_texture].
+		</constant>
+		<constant name="EMISSION_POINTS_ORDER_REVERSE" value="2" enum="PointsOrder">
+			Particles from points texture will emit in the reverse order in which they are stored in the [member emission_points_texture].
+		</constant>
+		<constant name="EMISSION_POINTS_ORDER_MAX" value="3" enum="PointsOrder">
+			Represents the size of the [enum PointsOrder] enum.
 		</constant>
 	</constants>
 </class>

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -312,7 +312,17 @@ void ParticlesMaterial::_update_shader() {
 	code += "\n";
 
 	if (emission_shape == EMISSION_SHAPE_POINTS || emission_shape == EMISSION_SHAPE_DIRECTED_POINTS) {
-		code += "	int point = min(emission_texture_point_count - 1, int(rand_from_seed(alt_seed) * float(emission_texture_point_count)));\n";
+		switch (emission_points_order) {
+			case EMISSION_POINTS_ORDER_RANDOM:
+				code += "	int point = min(emission_texture_point_count - 1, int(rand_from_seed(alt_seed) * float(emission_texture_point_count)));\n";
+				break;
+			case EMISSION_POINTS_ORDER_NORMAL:
+				code += "   int point = min(emission_texture_point_count -1, int(base_number) % emission_texture_point_count);\n";
+				break;
+			case EMISSION_POINTS_ORDER_REVERSE:
+				code += " int point = max(0, emission_texture_point_count - 1 - (int(base_number) % emission_texture_point_count));\n";
+				break;
+		}
 		code += "	ivec2 emission_tex_size = textureSize(emission_texture_points, 0);\n";
 		code += "	ivec2 emission_tex_ofs = ivec2(point % emission_tex_size.x, point / emission_tex_size.x);\n";
 	}
@@ -1010,6 +1020,13 @@ void ParticlesMaterial::set_emission_point_count(int p_count) {
 	VisualServer::get_singleton()->material_set_param(_get_material(), shader_names->emission_texture_point_count, p_count);
 }
 
+void ParticlesMaterial::set_emission_points_order(PointsOrder p_order) {
+	ERR_FAIL_INDEX(p_order, EMISSION_POINTS_ORDER_MAX);
+	emission_points_order = p_order;
+	_change_notify();
+	_queue_shader_change();
+}
+
 void ParticlesMaterial::set_emission_ring_height(float p_height) {
 	emission_ring_height = p_height;
 	VisualServer::get_singleton()->material_set_param(_get_material(), shader_names->emission_ring_height, p_height);
@@ -1053,6 +1070,10 @@ Ref<Texture> ParticlesMaterial::get_emission_color_texture() const {
 
 int ParticlesMaterial::get_emission_point_count() const {
 	return emission_point_count;
+}
+
+ParticlesMaterial::PointsOrder ParticlesMaterial::get_emission_points_order() const {
+	return emission_points_order;
 }
 
 float ParticlesMaterial::get_emission_ring_height() const {
@@ -1142,7 +1163,7 @@ void ParticlesMaterial::_validate_property(PropertyInfo &property) const {
 		property.usage = 0;
 	}
 
-	if ((property.name == "emission_point_texture" || property.name == "emission_color_texture") && (emission_shape != EMISSION_SHAPE_POINTS) && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
+	if ((property.name == "emission_point_texture" || property.name == "emission_color_texture" || property.name == "emission_points_order") && (emission_shape != EMISSION_SHAPE_POINTS) && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
 		property.usage = 0;
 	}
 
@@ -1219,6 +1240,9 @@ void ParticlesMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emission_point_count", "point_count"), &ParticlesMaterial::set_emission_point_count);
 	ClassDB::bind_method(D_METHOD("get_emission_point_count"), &ParticlesMaterial::get_emission_point_count);
 
+	ClassDB::bind_method(D_METHOD("set_emission_point_order", "emission_order"), &ParticlesMaterial::set_emission_points_order);
+	ClassDB::bind_method(D_METHOD("get_emission_point_order"), &ParticlesMaterial::get_emission_points_order);
+
 	ClassDB::bind_method(D_METHOD("set_emission_ring_radius", "radius"), &ParticlesMaterial::set_emission_ring_radius);
 	ClassDB::bind_method(D_METHOD("get_emission_ring_radius"), &ParticlesMaterial::get_emission_ring_radius);
 
@@ -1260,6 +1284,7 @@ void ParticlesMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "emission_normal_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_emission_normal_texture", "get_emission_normal_texture");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "emission_color_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_emission_color_texture", "get_emission_color_texture");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "emission_point_count", PROPERTY_HINT_RANGE, "0,1000000,1"), "set_emission_point_count", "get_emission_point_count");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "emission_points_order", PROPERTY_HINT_ENUM, "Random,Normal,Reverse"), "set_emission_point_order", "get_emission_point_order");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "emission_ring_radius", PROPERTY_HINT_RANGE, "0.01,1000,0.01,or_greater"), "set_emission_ring_radius", "get_emission_ring_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "emission_ring_inner_radius", PROPERTY_HINT_RANGE, "0.0,1000,0.01,or_greater"), "set_emission_ring_inner_radius", "get_emission_ring_inner_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "emission_ring_height", PROPERTY_HINT_RANGE, "0.0,100,0.01,or_greater"), "set_emission_ring_height", "get_emission_ring_height");
@@ -1353,6 +1378,11 @@ void ParticlesMaterial::_bind_methods() {
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_DIRECTED_POINTS);
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_RING);
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_MAX);
+
+	BIND_ENUM_CONSTANT(EMISSION_POINTS_ORDER_RANDOM);
+	BIND_ENUM_CONSTANT(EMISSION_POINTS_ORDER_NORMAL);
+	BIND_ENUM_CONSTANT(EMISSION_POINTS_ORDER_REVERSE);
+	BIND_ENUM_CONSTANT(EMISSION_POINTS_ORDER_MAX);
 }
 
 ParticlesMaterial::ParticlesMaterial() :

--- a/scene/resources/particles_material.h
+++ b/scene/resources/particles_material.h
@@ -73,16 +73,25 @@ public:
 		EMISSION_SHAPE_MAX
 	};
 
+	enum PointsOrder {
+		EMISSION_POINTS_ORDER_RANDOM,
+		EMISSION_POINTS_ORDER_NORMAL,
+		EMISSION_POINTS_ORDER_REVERSE,
+		EMISSION_POINTS_ORDER_MAX,
+
+	};
+
 private:
 	union MaterialKey {
 		// The bit size of the struct must be kept below or equal to 32 bits.
-		// Consider this when extending Flags, or EmissionShape.
+		// Consider this when extending Flags, EmissionShape or PointsOrder.
 		struct {
 			uint32_t texture_mask : 16;
 			uint32_t texture_color : 1;
 			uint32_t texture_initial_color : 1;
 			uint32_t flags : 4;
 			uint32_t emission_shape : 3;
+			uint32_t points_order : 2;
 			uint32_t trail_size_texture : 1;
 			uint32_t trail_color_texture : 1;
 			uint32_t invalid_key : 1;
@@ -122,6 +131,7 @@ private:
 		mk.texture_color = color_ramp.is_valid() ? 1 : 0;
 		mk.texture_initial_color = color_initial_ramp.is_valid() ? 1 : 0;
 		mk.emission_shape = emission_shape;
+		mk.points_order = emission_points_order;
 		mk.trail_color_texture = trail_color_modifier.is_valid() ? 1 : 0;
 		mk.trail_size_texture = trail_size_modifier.is_valid() ? 1 : 0;
 		mk.has_emission_color = emission_shape >= EMISSION_SHAPE_POINTS && emission_color_texture.is_valid();
@@ -227,6 +237,7 @@ private:
 	Ref<Texture> emission_point_texture;
 	Ref<Texture> emission_normal_texture;
 	Ref<Texture> emission_color_texture;
+	PointsOrder emission_points_order;
 	int emission_point_count;
 	float emission_ring_height;
 	float emission_ring_radius;
@@ -288,6 +299,7 @@ public:
 	void set_emission_normal_texture(const Ref<Texture> &p_normals);
 	void set_emission_color_texture(const Ref<Texture> &p_colors);
 	void set_emission_point_count(int p_count);
+	void set_emission_points_order(PointsOrder p_order);
 	void set_emission_ring_radius(float p_radius);
 	void set_emission_ring_inner_radius(float p_offset);
 	void set_emission_ring_height(float p_height);
@@ -300,6 +312,7 @@ public:
 	Ref<Texture> get_emission_normal_texture() const;
 	Ref<Texture> get_emission_color_texture() const;
 	int get_emission_point_count() const;
+	PointsOrder get_emission_points_order() const;
 	float get_emission_ring_radius() const;
 	float get_emission_ring_inner_radius() const;
 	float get_emission_ring_height() const;
@@ -335,5 +348,6 @@ public:
 VARIANT_ENUM_CAST(ParticlesMaterial::Parameter)
 VARIANT_ENUM_CAST(ParticlesMaterial::Flags)
 VARIANT_ENUM_CAST(ParticlesMaterial::EmissionShape)
+VARIANT_ENUM_CAST(ParticlesMaterial::PointsOrder)
 
 #endif // PARTICLES_MATERIAL_H


### PR DESCRIPTION
Implement particle spawn order options for points texture (GPUParticles only)