### PR TITLE
Remove ENET_DEBUG

### DIFF
--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -24,8 +24,8 @@ if env["builtin_enet"]:
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
     env_enet.Prepend(CPPPATH=[thirdparty_dir])
-    // For debug infor, add `ENET_DEBUG` to `CPPDEFINES` below. Note that this may enable calls to `perror`,
-    // which do not compile on MacOS.
+    // For debug info, add `ENET_DEBUG` to `CPPDEFINES` below. 
+    // Note that this may enable calls to `perror`, which do not compile on MacOS.
     env_enet.Append(CPPDEFINES=["GODOT_ENET"])
 
     env_thirdparty = env_enet.Clone()

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -24,8 +24,8 @@ if env["builtin_enet"]:
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
     env_enet.Prepend(CPPPATH=[thirdparty_dir])
-    // For debug info, add `ENET_DEBUG` to `CPPDEFINES` below. 
-    // Note that this may enable calls to `perror`, which do not compile on MacOS.
+    # For debug info, add `ENET_DEBUG` to `CPPDEFINES` below. 
+    # Note that this may enable calls to `perror`, which do not compile on MacOS.
     env_enet.Append(CPPDEFINES=["GODOT_ENET"])
 
     env_thirdparty = env_enet.Clone()

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -24,6 +24,8 @@ if env["builtin_enet"]:
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
     env_enet.Prepend(CPPPATH=[thirdparty_dir])
+    // For debug infor, add `ENET_DEBUG` to `CPPDEFINES` below. Note that this may enable calls to `perror`,
+    // which do not compile on MacOS.
     env_enet.Append(CPPDEFINES=["GODOT_ENET"])
 
     env_thirdparty = env_enet.Clone()

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -25,7 +25,7 @@ if env["builtin_enet"]:
 
     env_enet.Prepend(CPPPATH=[thirdparty_dir])
     # For debug info, add `ENET_DEBUG` to `CPPDEFINES` below. 
-    # Note that this may enable calls to `perror`, which do not compile on MacOS.
+    # Note that it may enable calls to `perror`, which do not compile on MacOS.
     env_enet.Append(CPPDEFINES=["GODOT_ENET"])
 
     env_thirdparty = env_enet.Clone()

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -25,7 +25,6 @@ if env["builtin_enet"]:
 
     env_enet.Prepend(CPPPATH=[thirdparty_dir])
     env_enet.Append(CPPDEFINES=["GODOT_ENET"])
-    env_enet.Append(CPPDEFINES=["ENET_DEBUG"])
 
     env_thirdparty = env_enet.Clone()
     env_thirdparty.disable_warnings()


### PR DESCRIPTION
This causes build failures in OSX (because of `perror`) and should never be added to the repo.