### PR TITLE
Add basic support for catch2

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -321,7 +321,7 @@ if env_base["build_custom_tests"]:
 	if sys.platform == "win32":
 		env_base.Append(CPPPATH=["C:\\Program Files (x86)\\catch2\\include"])
 		env_base.Append(LIBPATH=["C:\\Program Files (x86)\\catch2\\lib"])
-		env_base.Append(LIBS=["Catch2d.lib"])
+		env_base.Append(LIBS=[File("Catch2d.lib")])
 	else:
 		env_base.Append(CPPPATH=["/usr/local/include"])
 		env_base.Append(LIBPATH=["/usr/local/lib"])

--- a/SConstruct
+++ b/SConstruct
@@ -322,7 +322,7 @@ if env_base["build_custom_tests"]:
 		env_base.Append(CPPPATH=["C:\\Program Files (x86)\\catch2\\include"])
 		env_base.Append(LIBPATH=["C:\\Program Files (x86)\\catch2\\lib"])
 		env_base.Append(
-		    LIBS=[File("C:\\Program Files (x86)\\catch2\\lib\\Catch2d.lib")])
+		    LIBS=[File("C:\\Program Files (x86)\\catch2\\lib\\Catch2.lib")])
 	else:
 		env_base.Append(CPPPATH=["/usr/local/include"])
 		env_base.Append(LIBPATH=["/usr/local/lib"])

--- a/SConstruct
+++ b/SConstruct
@@ -131,6 +131,7 @@ opts.Add(BoolVariable("minizip", "Enable ZIP archive support using minizip", Tru
 opts.Add(BoolVariable("xaudio2", "Enable the XAudio2 audio driver", False))
 opts.Add("custom_modules", "A list of comma-separated directory paths containing custom modules to build.", "")
 opts.Add(BoolVariable("custom_modules_recursive", "Detect custom modules recursively for each specified path.", True))
+opts.Add(BoolVariable("build_custom_tests", "Include external module tests.", False))
 
 # Advanced options
 opts.Add(BoolVariable("dev", "If yes, alias for verbose=yes warnings=extra werror=yes", False))
@@ -315,6 +316,16 @@ Help(opts.GenerateHelpText(env_base))
 # add default include paths
 
 env_base.Prepend(CPPPATH=["#"])
+if env_base["build_custom_tests"]:
+	env_base.Append(CPPDEFINES=["CATCH_TESTS"])
+	if sys.platform == "win32":
+		env_base.Append(CPPPATH=["C:\\Program Files (x86)\\catch2\\include"])
+		env_base.Append(LIBPATH=["C:\\Program Files (x86)\\catch2\\lib"])
+		env_base.Append(LIBS=["Catch2d.lib"])
+	else:
+		env_base.Append(CPPPATH=["/usr/local/include"])
+		env_base.Append(LIBPATH=["/usr/local/lib"])
+		env_base.Append(LIBS=["libCatch2.a"])
 
 # configure ENV for platform
 env_base.platform_exporters = platform_exporters

--- a/SConstruct
+++ b/SConstruct
@@ -321,7 +321,8 @@ if env_base["build_custom_tests"]:
 	if sys.platform == "win32":
 		env_base.Append(CPPPATH=["C:\\Program Files (x86)\\catch2\\include"])
 		env_base.Append(LIBPATH=["C:\\Program Files (x86)\\catch2\\lib"])
-		env_base.Append(LIBS=[File("Catch2d.lib")])
+		env_base.Append(
+		    LIBS=[File("C:\\Program Files (x86)\\catch2\\lib\\Catch2d.lib")])
 	else:
 		env_base.Append(CPPPATH=["/usr/local/include"])
 		env_base.Append(LIBPATH=["/usr/local/lib"])

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -129,6 +129,9 @@ static int audio_driver_idx = -1;
 
 static bool editor = false;
 static bool project_manager = false;
+// When `test_external` is true, the program runs unit tests for external
+// game modules and then exits.
+static bool test_external = false;
 static String locale;
 static bool show_help = false;
 static bool auto_quit = false;
@@ -346,6 +349,7 @@ void Main::print_help(const char *p_binary) {
 #ifdef DEBUG_METHODS_ENABLED
 	OS::get_singleton()->print("  --gdnative-generate-json-api     Generate JSON dump of the Godot API for GDNative bindings.\n");
 #endif
+	OS::get_singleton()->print("  --test-external <test>           Run unit tests for external game modules.\n");
 	OS::get_singleton()->print("  --test <test>                    Run a unit test (");
 	const char **test_names = tests_get_names();
 	const char *comma = "";
@@ -1622,6 +1626,8 @@ bool Main::start() {
 			editor = true;
 		} else if (args[i] == "-p" || args[i] == "--project-manager") {
 			project_manager = true;
+		} else if (args[i] == "--test-external") {
+			test_external = true;
 #endif
 		} else if (args[i].length() && args[i][0] != '-' && positional_arg == "") {
 			positional_arg = args[i];
@@ -1759,6 +1765,10 @@ bool Main::start() {
 	}
 
 #endif
+	if (test_external) {
+		// Tell the platform main() to run tests and then stop.
+		return false;
+	}
 
 	if (script == "" && game_path == "" && String(GLOBAL_DEF("application/run/main_scene", "")) != "") {
 		game_path = GLOBAL_DEF("application/run/main_scene", "");

--- a/main/tests/catch_testing.h
+++ b/main/tests/catch_testing.h
@@ -1,0 +1,43 @@
+/* 
+ * Helper function for running tests on external modules.
+ * Copyright 2023 the halcyon authors
+ */
+
+#ifndef MAIN_TESTS_CATCH_TESTING_H
+#define MAIN_TESTS_CATCH_TESTING_H
+
+#ifdef CATCH_TESTS
+#include <catch2/catch_session.hpp>
+
+void run_catch_tests(int argc, char **argv) {
+
+Catch::Session session; // There must be exactly one instance
+
+  bool test_external = false;
+
+  // Build a new parser on top of Catch2's
+  using namespace Catch::Clara;
+	// Register the command line option for running Catch2 tests, so that its
+	// command line parser won't halt because it's unrecognized.
+  auto cli
+    = session.cli()           // Get Catch2's command line parser
+    | Opt(test_external) // bind variable to a new option, with a hint string
+        ["--test-external"]    // the option names it will respond to
+        ("The option that tells Godot to run external tests.");
+
+  // Now pass the new composite back to Catch2 so it uses that
+  session.cli(cli);
+
+  // Let Catch2 (using Clara) parse the command line
+  int returnCode = session.applyCommandLine(argc, argv);
+	if (returnCode != 0) {
+		fprintf(stderr, "Error parsing command line arguments for Catch2.");
+		return;
+	}
+	// This returns an int that's meant to propagate to the `main()` return value,
+	// but trying to return it leads to SIGABRT.
+	session.run();
+}
+#endif  // CATCH_TESTS
+
+#endif  // MAIN_TESTS_CATCH_TESTING_H

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -25,7 +25,6 @@ if env["builtin_enet"]:
 
     env_enet.Prepend(CPPPATH=[thirdparty_dir])
     env_enet.Append(CPPDEFINES=["GODOT_ENET"])
-    env_enet.Append(CPPDEFINES=["ENET_DEBUG"])
 
     env_thirdparty = env_enet.Clone()
     env_thirdparty.disable_warnings()

--- a/platform/osx/godot_main_osx.mm
+++ b/platform/osx/godot_main_osx.mm
@@ -29,39 +29,9 @@
 /*************************************************************************/
 
 #include "main/main.h"
+#include "main/tests/catch_testing.h"
 
 #include "os_osx.h"
-
-#if CATCH_TESTS
-#include <catch2/catch_session.hpp>
-int run_catch_tests(int argc, char **argv) {
-
-Catch::Session session; // There must be exactly one instance
-
-  bool test_external = false;
-
-  // Build a new parser on top of Catch2's
-  using namespace Catch::Clara;
-	// Register the command line option for running Catch2 tests, so that its
-	// command line parser won't halt because it's unrecognized.
-  auto cli
-    = session.cli()           // Get Catch2's command line parser
-    | Opt(test_external) // bind variable to a new option, with a hint string
-        ["--test-external"]    // the option names it will respond to
-        ("The option that tells Godot to run external tests.");
-
-  // Now pass the new composite back to Catch2 so it uses that
-  session.cli(cli);
-
-  // Let Catch2 (using Clara) parse the command line
-  int returnCode = session.applyCommandLine(argc, argv);
-	if (returnCode != 0) {
-		fprintf(stderr, "Error parsing command line arguments for Catch2.");
-		return returnCode;
-	}
-	return session.run();
-}
-#endif
 
 int main(int argc, char **argv) {
 	int first_arg = 1;
@@ -103,8 +73,10 @@ int main(int argc, char **argv) {
 	} else {
 		List<String> args = os.get_cmdline_args();
 		if (args.find("--test-external") != nullptr) {
-			#if CATCH_TESTS
+			#ifdef CATCH_TESTS
 			run_catch_tests(argc, argv);
+			#else
+			printf("Option --test_external is invalid because this program was built without Catch2.");
 			#endif
 		}
 	}

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -178,7 +178,7 @@ __declspec(dllexport) int widechar_main(int argc, wchar_t **argv) {
 		List<String> args = os.get_cmdline_args();
 		if (args.find("--test-external") != nullptr) {
 			#ifdef CATCH_TESTS
-			run_catch_tests(argc, argv);
+			run_catch_tests(argc, &argv_utf8[0]);
 			#else
 			printf("Option --test_external is invalid because this program was built without Catch2.");
 			#endif

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "main/main.h"
+#include "main/tests/catch_testing.h"
 #include "os_windows.h"
 
 #include <locale.h>
@@ -171,9 +172,18 @@ __declspec(dllexport) int widechar_main(int argc, wchar_t **argv) {
 		return 255;
 	}
 
-	if (Main::start())
-		os.run();
-	Main::cleanup();
+	if (Main::start()) {
+		os.run(); // it is actually the OS that decides how to run
+	} else {
+		List<String> args = os.get_cmdline_args();
+		if (args.find("--test-external") != nullptr) {
+			#ifdef CATCH_TESTS
+			run_catch_tests(argc, argv);
+			#else
+			printf("Option --test_external is invalid because this program was built without Catch2.");
+			#endif
+		}
+	}
 
 	for (int i = 0; i < argc; ++i) {
 		delete[] argv_utf8[i];

--- a/platform/x11/godot_x11.cpp
+++ b/platform/x11/godot_x11.cpp
@@ -34,6 +34,7 @@
 #include <unistd.h>
 
 #include "main/main.h"
+#include "main/tests/catch_testing.h"
 #include "os_x11.h"
 
 int main(int argc, char *argv[]) {
@@ -57,6 +58,15 @@ int main(int argc, char *argv[]) {
 
 	if (Main::start()) {
 		os.run(); // it is actually the OS that decides how to run
+	} else {
+		List<String> args = os.get_cmdline_args();
+		if (args.find("--test-external") != nullptr) {
+			#ifdef CATCH_TESTS
+			run_catch_tests(argc, argv);
+			#else
+			printf("Option --test_external is invalid because this program was built without Catch2.");
+			#endif
+		}
 	}
 	Main::cleanup();
 


### PR DESCRIPTION
A new scons option `build_custom_tests` decides whether to include the Catch2 library and related code in the build.

A new Godot executable option `--test-external` tells Godot to run tests