### PR TITLE
Adding unit tests to vs project generation configuration for scons.

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -785,7 +785,10 @@ def generate_vs_project(env, num_jobs):
 
                 if env["custom_modules"]:
                     common_build_postfix.append("custom_modules=%s" % env["custom_modules"])
-
+                
+                if env["build_custom_tests"]:
+                    common_build_postfix.append("build_custom_tests=%s" % env["build_custom_tests"])
+                
                 result = " ^& ".join(common_build_prefix + [" ".join([commands] + common_build_postfix)])
                 return result
 


### PR DESCRIPTION
Adding propagation for unit test configs to vsproject generation to allow for unit testing inside of visual studio.

Tested in halcyon-one project with visual studio in debug mode with existing unit tests in passing and failing modes.

Failing modes trigger breakpoints at failure, Passing all tests generates no output.