### PR TITLE
Adding visual studio debug output to windows terminal logger when bui…

### DIFF
--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -64,6 +64,10 @@ void WindowsTerminalLogger::logv(const char *p_format, va_list p_list, bool p_er
 	else
 		wprintf(L"%ls", wbuf);
 
+#ifdef DEBUG_ENABLED
+	OutputDebugStringW(wbuf);
+#endif
+
 	memfree(wbuf);
 
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
…lt in debug mode.

Tested via visual studio in debug, debug_release, and release modes w/test Halcyon-One project.