### PR TITLE
Adding safe cleanup of audio thread when enabled in windows OS for WA…

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -3960,6 +3960,10 @@ OS_Windows::~OS_Windows() {
 		wintab_WTClose(wtctx);
 		wtctx = 0;
 	}
+#ifdef WASAPI_ENABLED
+	driver_wasapi.finish();
+#endif
+
 #ifdef STDOUT_FILE
 	fclose(stdo);
 #endif


### PR DESCRIPTION
…SAPI.

Tested with Unit tests, Halcyon-One test project client / server and editor in release_debug / debug.

Fixes warning output as well as race condition shutdown crash in audio thread.