### PR TITLE
Change lib to lib64 on linux for catch2

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -323,6 +323,10 @@ if env_base["build_custom_tests"]:
 		env_base.Append(LIBPATH=["C:\\Program Files (x86)\\catch2\\lib"])
 		env_base.Append(
 		    LIBS=[File("C:\\Program Files (x86)\\catch2\\lib\\Catch2.lib")])
+    elif sys.platform == "linux":
+        env_base.Append(CPPPATH=["/usr/local/include"])
+        env_base.Append(LIBPATH=["/usr/local/lib64"])
+        env_base.Append(LIBS=["libCatch2.a"])
 	else:
 		env_base.Append(CPPPATH=["/usr/local/include"])
 		env_base.Append(LIBPATH=["/usr/local/lib"])

--- a/SConstruct
+++ b/SConstruct
@@ -325,7 +325,7 @@ if env_base["build_custom_tests"]:
 		    LIBS=[File("C:\\Program Files (x86)\\catch2\\lib\\Catch2.lib")])
 	else:
 		env_base.Append(CPPPATH=["/usr/local/include"])
-        if exists("/usr/local/lib64/libCatch2.a"):
+        if os.path.exists("/usr/local/lib64/libCatch2.a"):
             env_base.Append(LIBPATH=["/usr/local/lib64"])
         else:
             env_base.Append(LIBPATH=["/usr/local/lib"])

--- a/SConstruct
+++ b/SConstruct
@@ -317,14 +317,14 @@ Help(opts.GenerateHelpText(env_base))
 
 env_base.Prepend(CPPPATH=["#"])
 if env_base["build_custom_tests"]:
-	env_base.Append(CPPDEFINES=["CATCH_TESTS"])
-	if sys.platform == "win32":
-		env_base.Append(CPPPATH=["C:\\Program Files (x86)\\catch2\\include"])
-		env_base.Append(LIBPATH=["C:\\Program Files (x86)\\catch2\\lib"])
-		env_base.Append(
-		    LIBS=[File("C:\\Program Files (x86)\\catch2\\lib\\Catch2.lib")])
-	else:
-		env_base.Append(CPPPATH=["/usr/local/include"])
+    env_base.Append(CPPDEFINES=["CATCH_TESTS"])
+    if sys.platform == "win32":
+        env_base.Append(CPPPATH=["C:\\Program Files (x86)\\catch2\\include"])
+        env_base.Append(LIBPATH=["C:\\Program Files (x86)\\catch2\\lib"])
+        env_base.Append(
+            LIBS=[File("C:\\Program Files (x86)\\catch2\\lib\\Catch2.lib")])
+    else:
+        env_base.Append(CPPPATH=["/usr/local/include"])
         if os.path.exists("/usr/local/lib64/libCatch2.a"):
             env_base.Append(LIBPATH=["/usr/local/lib64"])
         else:

--- a/SConstruct
+++ b/SConstruct
@@ -323,14 +323,13 @@ if env_base["build_custom_tests"]:
 		env_base.Append(LIBPATH=["C:\\Program Files (x86)\\catch2\\lib"])
 		env_base.Append(
 		    LIBS=[File("C:\\Program Files (x86)\\catch2\\lib\\Catch2.lib")])
-    elif sys.platform == "linux":
-        env_base.Append(CPPPATH=["/usr/local/include"])
-        env_base.Append(LIBPATH=["/usr/local/lib64"])
-        env_base.Append(LIBS=["libCatch2.a"])
 	else:
 		env_base.Append(CPPPATH=["/usr/local/include"])
-		env_base.Append(LIBPATH=["/usr/local/lib"])
-		env_base.Append(LIBS=["libCatch2.a"])
+        if exists("/usr/local/lib64/libCatch2.a"):
+            env_base.Append(LIBPATH=["/usr/local/lib64"])
+        else:
+            env_base.Append(LIBPATH=["/usr/local/lib"])
+        env_base.Append(LIBS=["libCatch2.a"])
 
 # configure ENV for platform
 env_base.platform_exporters = platform_exporters


### PR DESCRIPTION
Certain linux distros install catch2 into /usr/local/lib64 and not /usr/local/lib like on MacOS.