### PR TITLE
New setup for catch testing module

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -131,7 +131,6 @@ opts.Add(BoolVariable("minizip", "Enable ZIP archive support using minizip", Tru
 opts.Add(BoolVariable("xaudio2", "Enable the XAudio2 audio driver", False))
 opts.Add("custom_modules", "A list of comma-separated directory paths containing custom modules to build.", "")
 opts.Add(BoolVariable("custom_modules_recursive", "Detect custom modules recursively for each specified path.", True))
-opts.Add(BoolVariable("build_custom_tests", "Include external module tests.", False))
 
 # Advanced options
 opts.Add(BoolVariable("dev", "If yes, alias for verbose=yes warnings=extra werror=yes", False))

--- a/SConstruct
+++ b/SConstruct
@@ -316,20 +316,6 @@ Help(opts.GenerateHelpText(env_base))
 # add default include paths
 
 env_base.Prepend(CPPPATH=["#"])
-if env_base["build_custom_tests"]:
-    env_base.Append(CPPDEFINES=["CATCH_TESTS"])
-    if sys.platform == "win32":
-        env_base.Append(CPPPATH=["C:\\Program Files (x86)\\catch2\\include"])
-        env_base.Append(LIBPATH=["C:\\Program Files (x86)\\catch2\\lib"])
-        env_base.Append(
-            LIBS=[File("C:\\Program Files (x86)\\catch2\\lib\\Catch2.lib")])
-    else:
-        env_base.Append(CPPPATH=["/usr/local/include"])
-        if os.path.exists("/usr/local/lib64/libCatch2.a"):
-            env_base.Append(LIBPATH=["/usr/local/lib64"])
-        else:
-            env_base.Append(LIBPATH=["/usr/local/lib"])
-        env_base.Append(LIBS=["libCatch2.a"])
 
 # configure ENV for platform
 env_base.platform_exporters = platform_exporters

--- a/platform/osx/godot_main_osx.mm
+++ b/platform/osx/godot_main_osx.mm
@@ -29,7 +29,7 @@
 /*************************************************************************/
 
 #include "main/main.h"
-#include "main/tests/catch_testing.h"
+#include "testing/run_catch.h"
 
 #include "os_osx.h"
 

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -29,7 +29,7 @@
 /*************************************************************************/
 
 #include "main/main.h"
-#include "main/tests/catch_testing.h"
+#include "testing/run_catch.h"
 #include "os_windows.h"
 
 #include <locale.h>

--- a/platform/x11/godot_x11.cpp
+++ b/platform/x11/godot_x11.cpp
@@ -34,7 +34,7 @@
 #include <unistd.h>
 
 #include "main/main.h"
-#include "main/tests/catch_testing.h"
+#include "testing/run_catch.h"
 #include "os_x11.h"
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
Scons code based on having Catch2 preinstalled at the system level is moved to `game_modules/testing/SCsub` in the `halcyon-zero` repo. The header with the helper function to start the Catch session is also moved to the testing module, so platform main() files are updated to use the new include path.

This will need to come into the halcyon-zero repo alongside the game_modules changes in https://github.com/pahdolabs/halcyon-zero/pull/2023