### PR TITLE
Remove custom test env variable from vsproj generation

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -786,9 +786,6 @@ def generate_vs_project(env, num_jobs):
                 if env["custom_modules"]:
                     common_build_postfix.append("custom_modules=%s" % env["custom_modules"])
                 
-                if env["build_custom_tests"]:
-                    common_build_postfix.append("build_custom_tests=%s" % env["build_custom_tests"])
-                
                 result = " ^& ".join(common_build_prefix + [" ".join([commands] + common_build_postfix)])
                 return result
 


### PR DESCRIPTION
The build_custom_tests env variable was removed in favour of using the built-in `module_testing_enabled` flag, so VSProj generation was failing due to the unrecognized environment variable.