### PR TITLE
Adding pre and post update tick methods to core engine.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,5 @@ $RECYCLE.BIN/
 *.msm
 *.msp
 *.lnk
+/.sentry-native
+godot.args.json

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -232,6 +232,10 @@ Engine::Engine() {
 	_physics_frames = 0;
 	_idle_frames = 0;
 	_in_physics = false;
+	//## START_ENGINE_EDIT
+	_in_pre_update = false;
+	_in_post_update = false;
+	//## END_ENGINE_EDIT
 	_frame_ticks = 0;
 	_frame_step = 0;
 	editor_hint = false;

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -233,8 +233,8 @@ Engine::Engine() {
 	_idle_frames = 0;
 	_in_physics = false;
 	//## START_ENGINE_EDIT
-	_in_pre_update = false;
-	_in_post_update = false;
+	_in_pre_process = false;
+	_in_post_process = false;
 	//## END_ENGINE_EDIT
 	_frame_ticks = 0;
 	_frame_step = 0;

--- a/core/engine.h
+++ b/core/engine.h
@@ -66,6 +66,11 @@ private:
 	uint64_t _idle_frames;
 	bool _in_physics;
 
+	//## START_ENGINE_EDIT
+	bool _in_pre_update : 1;
+	bool _in_post_update : 1;
+	//## END_ENGINE_EDIT
+
 	List<Singleton> singletons;
 	Map<StringName, Object *> singleton_ptrs;
 
@@ -92,6 +97,11 @@ public:
 	uint64_t get_physics_frames() const { return _physics_frames; }
 	uint64_t get_idle_frames() const { return _idle_frames; }
 	bool is_in_physics_frame() const { return _in_physics; }
+	//## BEGIN_ENGINE_EDIT
+	bool is_in_pre_update() const { return _in_pre_update; }
+	bool is_in_post_update() const { return _in_post_update; }
+	//## END_ENGINE_EDIT
+
 	uint64_t get_idle_frame_ticks() const { return _frame_ticks; }
 	float get_idle_frame_step() const { return _frame_step; }
 	float get_physics_interpolation_fraction() const { return _physics_interpolation_fraction; }

--- a/core/engine.h
+++ b/core/engine.h
@@ -67,8 +67,8 @@ private:
 	bool _in_physics;
 
 	//## START_ENGINE_EDIT
-	bool _in_pre_update : 1;
-	bool _in_post_update : 1;
+	bool _in_pre_process : 1;
+	bool _in_post_process : 1;
 	//## END_ENGINE_EDIT
 
 	List<Singleton> singletons;
@@ -98,8 +98,8 @@ public:
 	uint64_t get_idle_frames() const { return _idle_frames; }
 	bool is_in_physics_frame() const { return _in_physics; }
 	//## BEGIN_ENGINE_EDIT
-	bool is_in_pre_update() const { return _in_pre_update; }
-	bool is_in_post_update() const { return _in_post_update; }
+	bool is_in_pre_process() const { return _in_pre_process; }
+	bool is_in_post_process() const { return _in_post_process; }
 	//## END_ENGINE_EDIT
 
 	uint64_t get_idle_frame_ticks() const { return _frame_ticks; }

--- a/core/os/main_loop.cpp
+++ b/core/os/main_loop.cpp
@@ -45,6 +45,10 @@ void MainLoop::_bind_methods() {
 	BIND_VMETHOD(MethodInfo("_initialize"));
 	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_iteration", PropertyInfo(Variant::REAL, "delta")));
 	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_idle", PropertyInfo(Variant::REAL, "delta")));
+	//## BEGIN_ENGINE_EDIT
+	BIND_VMETHOD(MethodInfo("_pre_update", PropertyInfo(Variant::REAL, "delta")));
+	BIND_VMETHOD(MethodInfo("_post_update", PropertyInfo(Variant::REAL, "delta")));
+	//## END_ENGINE_EDIT
 	BIND_VMETHOD(MethodInfo("_drop_files", PropertyInfo(Variant::POOL_STRING_ARRAY, "files"), PropertyInfo(Variant::INT, "from_screen")));
 	BIND_VMETHOD(MethodInfo("_finalize"));
 
@@ -113,6 +117,18 @@ bool MainLoop::idle(float p_time) {
 
 	return false;
 }
+//## BEGIN_ENGINE_UPDATE
+void MainLoop::pre_update(float p_time) {
+	if (get_script_instance()) {
+		get_script_instance()->call("_pre_update", p_time);
+	}
+}
+void MainLoop::post_update(float p_time) {
+	if (get_script_instance()) {
+		get_script_instance()->call("_post_update", p_time);
+	}
+}
+//## END_ENGINE_UPDATE
 
 void MainLoop::drop_files(const Vector<String> &p_files, int p_from_screen) {
 	if (get_script_instance()) {

--- a/core/os/main_loop.cpp
+++ b/core/os/main_loop.cpp
@@ -46,8 +46,10 @@ void MainLoop::_bind_methods() {
 	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_iteration", PropertyInfo(Variant::REAL, "delta")));
 	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_idle", PropertyInfo(Variant::REAL, "delta")));
 	//## BEGIN_ENGINE_EDIT
-	BIND_VMETHOD(MethodInfo("_pre_update", PropertyInfo(Variant::REAL, "delta")));
-	BIND_VMETHOD(MethodInfo("_post_update", PropertyInfo(Variant::REAL, "delta")));
+	BIND_VMETHOD(MethodInfo("_process", PropertyInfo(Variant::REAL, "delta")));
+	BIND_VMETHOD(MethodInfo("_process_physics", PropertyInfo(Variant::REAL, "delta")));
+	BIND_VMETHOD(MethodInfo("_pre_process", PropertyInfo(Variant::REAL, "delta")));
+	BIND_VMETHOD(MethodInfo("_post_process", PropertyInfo(Variant::REAL, "delta")));
 	//## END_ENGINE_EDIT
 	BIND_VMETHOD(MethodInfo("_drop_files", PropertyInfo(Variant::POOL_STRING_ARRAY, "files"), PropertyInfo(Variant::INT, "from_screen")));
 	BIND_VMETHOD(MethodInfo("_finalize"));
@@ -118,14 +120,24 @@ bool MainLoop::idle(float p_time) {
 	return false;
 }
 //## BEGIN_ENGINE_UPDATE
-void MainLoop::pre_update(float p_time) {
+void MainLoop::process(float p_time) {
 	if (get_script_instance()) {
-		get_script_instance()->call("_pre_update", p_time);
+		get_script_instance()->call("_process", p_time);
 	}
 }
-void MainLoop::post_update(float p_time) {
+void MainLoop::process_physics(float p_time) {
 	if (get_script_instance()) {
-		get_script_instance()->call("_post_update", p_time);
+		get_script_instance()->call("_process_physics", p_time);
+	}
+}
+void MainLoop::pre_process(float p_time) {
+	if (get_script_instance()) {
+		get_script_instance()->call("_pre_process", p_time);
+	}
+}
+void MainLoop::post_process(float p_time) {
+	if (get_script_instance()) {
+		get_script_instance()->call("_post_process", p_time);
 	}
 }
 //## END_ENGINE_UPDATE

--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -71,6 +71,10 @@ public:
 	virtual void iteration_end() {}
 	virtual void poll_net() {}
 	virtual bool idle(float p_time);
+	//## BEGIN_ENGINE_EDIT
+	virtual void pre_update(float p_time);
+	virtual void post_update(float p_time);
+	//## END_ENGINE_EDIT
 	virtual void finish();
 
 	virtual void drop_files(const Vector<String> &p_files, int p_from_screen = 0);

--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -72,8 +72,10 @@ public:
 	virtual void poll_net() {}
 	virtual bool idle(float p_time);
 	//## BEGIN_ENGINE_EDIT
-	virtual void pre_update(float p_time);
-	virtual void post_update(float p_time);
+	virtual void process(float p_time);
+	virtual void process_physics(float p_time);	
+	virtual void pre_process(float p_time);
+	virtual void post_process(float p_time);
 	//## END_ENGINE_EDIT
 	virtual void finish();
 

--- a/doc/classes/MainLoop.xml
+++ b/doc/classes/MainLoop.xml
@@ -101,13 +101,30 @@
 				If implemented, the method must return a boolean value. [code]true[/code] ends the main loop, while [code]false[/code] lets it proceed to the next frame.
 			</description>
 		</method>
-		<method name="_post_update" qualifiers="virtual">
+		<method name="_post_process" qualifiers="virtual">
 			<return type="void" />
 			<argument index="0" name="delta" type="float" />
 			<description>
+			The post process event is called each frame after pre-process, physics, and process.  It is called before rendering.
+			Corresponds to the [constant NOTIFICATION_POST_PROCESS] notification in [method Object._notification].
 			</description>
 		</method>
-		<method name="_pre_update" qualifiers="virtual">
+		<method name="_pre_process" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="delta" type="float" />
+			<description>
+			The pre process event is called each frame at the beginning of the main loop tick.  It is called before physics, process, and post_process.
+			Corresponds to the [constant NOTIFICATION_PRE_PROCESS] notification in [method Object._notification].
+			</description>
+		</method>
+		<method name="_process" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="delta" type="float" />
+			<description>
+			The process event is called each frame once.  It is called after pre_process and physics, but is called before post_process and rendering.
+			</description>
+		</method>
+		<method name="_process_physics" qualifiers="virtual">
 			<return type="void" />
 			<argument index="0" name="delta" type="float" />
 			<description>

--- a/doc/classes/MainLoop.xml
+++ b/doc/classes/MainLoop.xml
@@ -101,6 +101,18 @@
 				If implemented, the method must return a boolean value. [code]true[/code] ends the main loop, while [code]false[/code] lets it proceed to the next frame.
 			</description>
 		</method>
+		<method name="_post_update" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="delta" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_pre_update" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="delta" type="float" />
+			<description>
+			</description>
+		</method>
 		<method name="finish">
 			<return type="void" />
 			<description>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -711,6 +711,12 @@
 				Enables unhandled key input processing. Enabled automatically if [method _unhandled_key_input] is overridden. Any calls to this before [method _ready] will be ignored.
 			</description>
 		</method>
+		<method name="set_scene_inherited_state">
+			<return type="void" />
+			<argument index="0" name="arg0" type="SceneState" />
+			<description>
+			</description>
+		</method>
 		<method name="set_scene_instance_load_placeholder">
 			<return type="void" />
 			<argument index="0" name="load_placeholder" type="bool" />

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -64,6 +64,24 @@
 				[b]Note:[/b] This method is only called if the node is present in the scene tree (i.e. if it's not an orphan).
 			</description>
 		</method>
+		<method name="_post_process" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="delta" type="float" />
+			<description>
+				The post process event is called each frame after pre-process, physics, and process.  It is called before rendering.
+				Corresponds to the [constant NOTIFICATION_POST_PROCESS] notification in [method Object._notification].
+				[b]Note:[/b] This method is only called if the node is present in the scene tree (i.e. if it's not an orphan).
+			</description>
+		</method>
+		<method name="_pre_process" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="delta" type="float" />
+			<description>
+				The pre process event is called each frame at the beginning of the main loop tick.  It is called before physics, process, and post_process.
+				Corresponds to the [constant NOTIFICATION_PRE_PROCESS] notification in [method Object._notification].
+				[b]Note:[/b] This method is only called if the node is present in the scene tree (i.e. if it's not an orphan).
+			</description>
+		</method>
 		<method name="_process" qualifiers="virtual">
 			<return type="void" />
 			<argument index="0" name="delta" type="float" />
@@ -139,6 +157,20 @@
 				Adds the node to a group. Groups are helpers to name and organize a subset of nodes, for example "enemies" or "collectables". A node can be in any number of groups. Nodes can be assigned a group at any time, but will not be added until they are inside the scene tree (see [method is_inside_tree]). See notes in the description, and the group methods in [SceneTree].
 				The [code]persistent[/code] option is used when packing node to [PackedScene] and saving to file. Non-persistent groups aren't stored.
 				[b]Note:[/b] For performance reasons, the order of node groups is [i]not[/i] guaranteed. The order of node groups should not be relied upon as it can vary across project runs.
+			</description>
+		</method>
+		<method name="can_post_process" qualifiers="const">
+			<return type="bool" />
+			<description>
+				This variable determines if a node will be possibly ticked during the post_process events.  
+				Make sure its marked as true to enable pre-process ticking.
+			</description>
+		</method>
+		<method name="can_pre_process" qualifiers="const">
+			<return type="bool" />
+			<description>
+				This variable determines if a node will be possibly ticked during the pre_process events. 
+				Make sure its marked as true to enable pre-process ticking.
 			</description>
 		</method>
 		<method name="can_process" qualifiers="const">
@@ -415,6 +447,18 @@
 				Returns [code]true[/code] if internal physics processing is enabled (see [method set_physics_process_internal]).
 			</description>
 		</method>
+		<method name="is_post_processing" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if post processing is enabled (see [method post_process]).
+			</description>
+		</method>
+		<method name="is_pre_processing" qualifiers="const">
+			<return type="bool" />
+			<description>
+			Returns [code]true[/code] if pre processing is enabled (see [method pre_process]).
+			</description>
+		</method>
 		<method name="is_processing" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -652,6 +696,27 @@
 				Sets the folded state of the node in the Scene dock.
 			</description>
 		</method>
+		<method name="set_manual_post_process">
+			<return type="void" />
+			<argument index="0" name="enable" type="bool" />
+			<description>
+				Set this if your node will be in charge of manually handling post_process events.  Useful for changing the order from script->C++ to C++ -> Script.
+			</description>
+		</method>
+		<method name="set_manual_pre_process">
+			<return type="void" />
+			<argument index="0" name="enable" type="bool" />
+			<description>
+				Set this if your node will be in charge of manually handling pre_process events.  Useful for changing the order from script->C++ to C++ -> Script.
+			</description>
+		</method>
+		<method name="set_manual_process">
+			<return type="void" />
+			<argument index="0" name="enable" type="bool" />
+			<description>
+				Set this if your node will be in charge of manually handling process events.  Useful for changing the order from script->C++ to C++ -> Script.
+			</description>
+		</method>
 		<method name="set_network_master">
 			<return type="void" />
 			<argument index="0" name="id" type="int" />
@@ -673,6 +738,18 @@
 			<description>
 				Enables or disables internal physics for this node. Internal physics processing happens in isolation from the normal [method _physics_process] calls and is used by some nodes internally to guarantee proper functioning even if the node is paused or physics processing is disabled for scripting ([method set_physics_process]). Only useful for advanced uses to manipulate built-in nodes' behavior.
 				[b]Warning:[/b] Built-in Nodes rely on the internal processing for their own logic, so changing this value from your code may lead to unexpected behavior. Script access to this internal logic is provided for specific advanced uses, but is unsafe and not supported.
+			</description>
+		</method>
+		<method name="set_post_process">
+			<return type="void" />
+			<argument index="0" name="enable" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="set_pre_process">
+			<return type="void" />
+			<argument index="0" name="enable" type="bool" />
+			<description>
 			</description>
 		</method>
 		<method name="set_process">
@@ -868,6 +945,18 @@
 		</constant>
 		<constant name="NOTIFICATION_RESET_PHYSICS_INTERPOLATION" value="28">
 			Notification received when [method reset_physics_interpolation] is called on the node or parent nodes.
+		</constant>
+		<constant name="NOTIFICATION_PRE_INTERNAL_PROCESS" value="29">
+			Notification received when pre_process is called for internal nodes.
+		</constant>
+		<constant name="NOTIFICATION_PRE_PROCESS" value="30">
+			Notification received when pre_process is called for nodes.
+		</constant>
+		<constant name="NOTIFICATION_POST_INTERNAL_PROCESS" value="31">
+			Notification received when post_process is called for internal nodes.
+		</constant>
+		<constant name="NOTIFICATION_POST_PROCESS" value="32">
+			Notification received when post_process is called for nodes.
 		</constant>
 		<constant name="NOTIFICATION_WM_MOUSE_ENTER" value="1002">
 			Notification received from the OS when the mouse enters the game window.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2258,6 +2258,13 @@ bool Main::iteration() {
 
 	last_ticks = ticks;
 
+	//## BEGIN_ENGINE_EDIT
+	{
+		ZoneScopedN("Main::iteration::PreUpdateProcess");
+		OS::get_singleton()->get_main_loop()->pre_update(step * time_scale);
+	}
+	//## END_ENGINE_EDIT
+
 	static const int max_physics_steps = 8;
 	if (fixed_fps == -1 && advance.physics_steps > max_physics_steps) {
 		step -= (advance.physics_steps - max_physics_steps) * frame_slice;
@@ -2333,6 +2340,13 @@ bool Main::iteration() {
 		visual_server_callbacks->flush();
 		message_queue->flush();
 	}
+
+	//## BEGIN_ENGINE_EDIT
+	{
+		ZoneScopedN("Main::iteration::PostUpdateProcess");
+		OS::get_singleton()->get_main_loop()->post_update(step * time_scale);
+	}
+	//## END_ENGINE_EDIT
 
 	VisualServer::get_singleton()->sync(); //sync if still drawing from previous frames.
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2260,8 +2260,8 @@ bool Main::iteration() {
 
 	//## BEGIN_ENGINE_EDIT
 	{
-		ZoneScopedN("Main::iteration::PreUpdateProcess");
-		OS::get_singleton()->get_main_loop()->pre_update(step * time_scale);
+		ZoneScopedN("Main::iteration::PreProcess");
+		OS::get_singleton()->get_main_loop()->pre_process(step * time_scale);
 	}
 	//## END_ENGINE_EDIT
 
@@ -2313,6 +2313,7 @@ bool Main::iteration() {
 
 			Physics2DServer::get_singleton()->end_sync();
 			Physics2DServer::get_singleton()->step(frame_slice * time_scale);
+			OS::get_singleton()->get_main_loop()->process_physics(step * time_scale);
 		}
 
 		message_queue->flush();
@@ -2336,6 +2337,8 @@ bool Main::iteration() {
 		ZoneScopedN("Main::iteration::IdleProcess");
 		if (OS::get_singleton()->get_main_loop()->idle(step * time_scale)) {
 			exit = true;
+		} else {
+			OS::get_singleton()->get_main_loop()->process(step * time_scale);
 		}
 		visual_server_callbacks->flush();
 		message_queue->flush();
@@ -2343,8 +2346,8 @@ bool Main::iteration() {
 
 	//## BEGIN_ENGINE_EDIT
 	{
-		ZoneScopedN("Main::iteration::PostUpdateProcess");
-		OS::get_singleton()->get_main_loop()->post_update(step * time_scale);
+		ZoneScopedN("Main::iteration::PostProcess");
+		OS::get_singleton()->get_main_loop()->post_process(step * time_scale);
 	}
 	//## END_ENGINE_EDIT
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -143,6 +143,15 @@ private:
 		bool physics_process : 1;
 		bool idle_process : 1;
 
+		//## BEGIN_ENGINE_EDIT
+		bool pre_update_process : 1;
+		bool post_update_process : 1;
+
+		bool manual_process : 1;
+		bool manual_pre_update : 1;
+		bool manual_post_update : 1;
+		//## END_ENGINE_EDIT
+
 		bool physics_process_internal : 1;
 		bool idle_process_internal : 1;
 
@@ -280,6 +289,14 @@ public:
 		NOTIFICATION_INTERNAL_PHYSICS_PROCESS = 26,
 		NOTIFICATION_POST_ENTER_TREE = 27,
 		NOTIFICATION_RESET_PHYSICS_INTERPOLATION = 28,
+
+		//## BEGIN_ENGINE_EDIT
+		NOTIFICATION_PRE_UPDATE_INTERNAL_PROCESS = 29,
+		NOTIFICATION_PRE_UPDATE_PROCESS = 30,
+		NOTIFICATION_POST_UPDATE_INTERNAL_PROCESS = 31,
+		NOTIFICATION_POST_UPDATE_PROCESS = 32,
+		//## END_ENGINE_EDIT
+
 		//keep these linked to node
 		NOTIFICATION_WM_MOUSE_ENTER = MainLoop::NOTIFICATION_WM_MOUSE_ENTER,
 		NOTIFICATION_WM_MOUSE_EXIT = MainLoop::NOTIFICATION_WM_MOUSE_EXIT,
@@ -392,6 +409,14 @@ public:
 	void set_physics_process(bool p_process);
 	float get_physics_process_delta_time() const;
 	bool is_physics_processing() const;
+
+	//## BEGIN_ENGINE_EDIT
+	void Node::set_pre_process(bool p_pre_process);
+	void Node::set_post_process(bool p_pre_process);
+	void Node::set_manual_process(bool manual);
+	void Node::set_manual_pre_process(bool manual);
+	void Node::set_manual_post_process(bool manual);
+	//## END_ENGINE_EDIT
 
 	void set_process(bool p_idle_process);
 	float get_process_delta_time() const;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -144,12 +144,12 @@ private:
 		bool idle_process : 1;
 
 		//## BEGIN_ENGINE_EDIT
-		bool pre_update_process : 1;
-		bool post_update_process : 1;
+		bool pre_process : 1;
+		bool post_process : 1;
 
 		bool manual_process : 1;
-		bool manual_pre_update : 1;
-		bool manual_post_update : 1;
+		bool manual_pre_process : 1;
+		bool manual_post_process : 1;
 		//## END_ENGINE_EDIT
 
 		bool physics_process_internal : 1;
@@ -291,10 +291,10 @@ public:
 		NOTIFICATION_RESET_PHYSICS_INTERPOLATION = 28,
 
 		//## BEGIN_ENGINE_EDIT
-		NOTIFICATION_PRE_UPDATE_INTERNAL_PROCESS = 29,
-		NOTIFICATION_PRE_UPDATE_PROCESS = 30,
-		NOTIFICATION_POST_UPDATE_INTERNAL_PROCESS = 31,
-		NOTIFICATION_POST_UPDATE_PROCESS = 32,
+		NOTIFICATION_PRE_INTERNAL_PROCESS = 29,
+		NOTIFICATION_PRE_PROCESS = 30,
+		NOTIFICATION_POST_INTERNAL_PROCESS = 31,
+		NOTIFICATION_POST_PROCESS = 32,
 		//## END_ENGINE_EDIT
 
 		//keep these linked to node
@@ -413,9 +413,13 @@ public:
 	//## BEGIN_ENGINE_EDIT
 	void Node::set_pre_process(bool p_pre_process);
 	void Node::set_post_process(bool p_pre_process);
+	bool Node::is_pre_processing() const;
+	bool Node::can_pre_process() const;
 	void Node::set_manual_process(bool manual);
 	void Node::set_manual_pre_process(bool manual);
 	void Node::set_manual_post_process(bool manual);
+	bool Node::is_post_processing() const;
+	bool Node::can_post_process() const;
 	//## END_ENGINE_EDIT
 
 	void set_process(bool p_idle_process);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -588,6 +588,28 @@ void SceneTree::poll_net() {
 		multiplayer->poll();
 	}
 }
+//## BEGIN_ENGINE_EDIT
+void SceneTree::pre_update(float p_time) {
+	++root_lock;
+	MainLoop::pre_update(p_time);
+
+	emit_signal("pre_update_process");
+	_notify_group_pause("pre_update_process_internal", Node::NOTIFICATION_PRE_UPDATE_INTERNAL_PROCESS);
+	_notify_group_pause("pre_update_process", Node::NOTIFICATION_PRE_UPDATE_PROCESS);
+
+	--root_lock;
+}
+void SceneTree::post_update(float p_time) {
+	++root_lock;
+	MainLoop::post_update(p_time);
+
+	emit_signal("post_update_process");
+	_notify_group_pause("post_update_process_internal", Node::NOTIFICATION_POST_UPDATE_INTERNAL_PROCESS);
+	_notify_group_pause("post_update_process", Node::NOTIFICATION_POST_UPDATE_PROCESS);
+
+	--root_lock;
+}
+//## END_ENGINE_EDIT
 
 bool SceneTree::idle(float p_time) {
 	//print_line("ram: "+itos(OS::get_singleton()->get_static_memory_usage())+" sram: "+itos(OS::get_singleton()->get_dynamic_memory_usage()));

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -589,23 +589,23 @@ void SceneTree::poll_net() {
 	}
 }
 //## BEGIN_ENGINE_EDIT
-void SceneTree::pre_update(float p_time) {
+void SceneTree::pre_process(float p_time) {
 	++root_lock;
-	MainLoop::pre_update(p_time);
+	MainLoop::pre_process(p_time);
 
-	emit_signal("pre_update_process");
-	_notify_group_pause("pre_update_process_internal", Node::NOTIFICATION_PRE_UPDATE_INTERNAL_PROCESS);
-	_notify_group_pause("pre_update_process", Node::NOTIFICATION_PRE_UPDATE_PROCESS);
+	emit_signal("pre_process");
+	_notify_group_pause("pre_process_internal", Node::NOTIFICATION_PRE_INTERNAL_PROCESS);
+	_notify_group_pause("pre_process", Node::NOTIFICATION_PRE_PROCESS);
 
 	--root_lock;
 }
-void SceneTree::post_update(float p_time) {
+void SceneTree::post_process(float p_time) {
 	++root_lock;
-	MainLoop::post_update(p_time);
+	MainLoop::post_process(p_time);
 
-	emit_signal("post_update_process");
-	_notify_group_pause("post_update_process_internal", Node::NOTIFICATION_POST_UPDATE_INTERNAL_PROCESS);
-	_notify_group_pause("post_update_process", Node::NOTIFICATION_POST_UPDATE_PROCESS);
+	emit_signal("post_process");
+	_notify_group_pause("post_process_internal", Node::NOTIFICATION_POST_INTERNAL_PROCESS);
+	_notify_group_pause("post_process", Node::NOTIFICATION_POST_PROCESS);
 
 	--root_lock;
 }

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -310,6 +310,11 @@ public:
 	virtual void poll_net();
 	virtual bool idle(float p_time);
 
+	//## BEGIN_ENGINE_EDIT
+	virtual void pre_update(float p_time);
+	virtual void post_update(float p_time);
+	//## END_ENGINE_EDIT
+
 	virtual void finish();
 
 	bool is_auto_accept_quit() const;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -311,8 +311,8 @@ public:
 	virtual bool idle(float p_time);
 
 	//## BEGIN_ENGINE_EDIT
-	virtual void pre_update(float p_time);
-	virtual void post_update(float p_time);
+	virtual void pre_process(float p_time);
+	virtual void post_process(float p_time);
 	//## END_ENGINE_EDIT
 
 	virtual void finish();

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -93,6 +93,11 @@ SceneStringNames::SceneStringNames() {
 	_physics_process = StaticCString::create("_physics_process");
 	_process = StaticCString::create("_process");
 
+	//## BEGIN_ENGINE_EDIT
+	_pre_update = StaticCString::create("_pre_update");
+	_post_update = StaticCString::create("_post_update");
+	//## END_ENGINE_EDIT
+
 	_enter_tree = StaticCString::create("_enter_tree");
 	_exit_tree = StaticCString::create("_exit_tree");
 	_enter_world = StaticCString::create("_enter_world");

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -94,8 +94,8 @@ SceneStringNames::SceneStringNames() {
 	_process = StaticCString::create("_process");
 
 	//## BEGIN_ENGINE_EDIT
-	_pre_update = StaticCString::create("_pre_update");
-	_post_update = StaticCString::create("_post_update");
+	_pre_process = StaticCString::create("_pre_process");
+	_post_process = StaticCString::create("_post_process");
 	//## END_ENGINE_EDIT
 
 	_enter_tree = StaticCString::create("_enter_tree");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -111,6 +111,10 @@ public:
 
 	StringName _physics_process;
 	StringName _process;
+	//## BEGIN_ENGINE_UPDATE
+	StringName _pre_update;
+	StringName _post_update;
+	//## END_ENGINE_UPDATE
 	StringName _enter_world;
 	StringName _exit_world;
 	StringName _enter_tree;

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -112,8 +112,8 @@ public:
 	StringName _physics_process;
 	StringName _process;
 	//## BEGIN_ENGINE_UPDATE
-	StringName _pre_update;
-	StringName _post_update;
+	StringName _pre_process;
+	StringName _post_process;
 	//## END_ENGINE_UPDATE
 	StringName _enter_world;
 	StringName _exit_world;


### PR DESCRIPTION
Added pre and post ticks to the engine to support additional update group functionality.
Added manual update flags for allowing nodes to tick their own update methods in gdscript after their C++ tick to support base classes running logic before gdscripts get a chance to touch it.

Please take a look at the terminology and critique it!

== Testing
Tested with halcyon-one project in debug / release_debug in editor and standalone.