### PR TITLE
Allow the server platform to run tests

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1343,6 +1343,16 @@ void EditorFileSystem::_save_late_updated_files() {
 }
 
 Vector<String> EditorFileSystem::_get_dependencies(const String &p_path) {
+	// Avoid error spam on first opening of a not yet imported project by treating the following situation
+	// as a benign one, not letting the file open error happen: the resource is of an importable type but
+	// it has not been imported yet.
+	if (ResourceFormatImporter::get_singleton()->recognize_path(p_path)) {
+		const String &internal_path = ResourceFormatImporter::get_singleton()->get_internal_resource_path(p_path);
+		if (!internal_path.empty() && !FileAccess::exists(internal_path)) { // If path is empty (error), keep the code flow to the error.
+			return Vector<String>();
+		}
+	}
+	
 	List<String> deps;
 	ResourceLoader::get_dependencies(p_path, &deps);
 

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4672,13 +4672,12 @@ void _update_all_gizmos(Node *p_node) {
 }
 
 void SpatialEditor::update_all_gizmos(Node *p_node) {
+	if (!p_node && SceneTree::get_singleton()) {
+		p_node = SceneTree::get_singleton()->get_root();
+	}
 	if (!p_node) {
-		if (SceneTree::get_singleton()) {
-			p_node = SceneTree::get_singleton()->get_root();
-		} else {
-			// No scene tree, so nothing to update.
-			return;
-		}
+		// No scene tree, so nothing to update.
+		return;
 	}
 	_update_all_gizmos(p_node);
 }

--- a/platform/server/godot_server.cpp
+++ b/platform/server/godot_server.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "main/main.h"
+#include "testing/run_catch.h"
 #include "os_server.h"
 
 int main(int argc, char *argv[]) {
@@ -38,8 +39,19 @@ int main(int argc, char *argv[]) {
 	if (err != OK)
 		return 255;
 
-	if (Main::start())
+	if (Main::start()) {
 		os.run(); // it is actually the OS that decides how to run
+	}
+	else {
+		List<String> args = os.get_cmdline_args();
+		if (args.find("--test-external") != nullptr) {
+			#ifdef CATCH_TESTS
+			run_catch_tests(argc, argv);
+			#else
+			printf("Option --test_external is invalid because this program was built without Catch2.");
+			#endif
+		}
+	}
 	Main::cleanup();
 
 	return os.get_exit_code();

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -411,15 +411,15 @@ public:
 	bool is_physics_processing() const;
 
 	//## BEGIN_ENGINE_EDIT
-	void Node::set_pre_process(bool p_pre_process);
-	void Node::set_post_process(bool p_pre_process);
-	bool Node::is_pre_processing() const;
-	bool Node::can_pre_process() const;
-	void Node::set_manual_process(bool manual);
-	void Node::set_manual_pre_process(bool manual);
-	void Node::set_manual_post_process(bool manual);
-	bool Node::is_post_processing() const;
-	bool Node::can_post_process() const;
+	void set_pre_process(bool p_pre_process);
+	void set_post_process(bool p_pre_process);
+	bool is_pre_processing() const;
+	bool can_pre_process() const;
+	void set_manual_process(bool manual);
+	void set_manual_pre_process(bool manual);
+	void set_manual_post_process(bool manual);
+	bool is_post_processing() const;
+	bool can_post_process() const;
 	//## END_ENGINE_EDIT
 
 	void set_process(bool p_idle_process);


### PR DESCRIPTION
It was while debugging FMOD that I realized this entire time that the server platform couldn't run tests, making the test runner on our CI just spin in butter for a bit and report nothing useful.

Also:
- Fixes a segmentation fault using a fix backported from Godot 4 with spatial gizmo plugins (discovered happening from server platform shutting down)
- Fixes an issue with Kirk's new code where members of a header file had the class:: prefix and it failed to compile on non-msvc