### PR TITLE
Adding auto-size to aspect ratio box to automatically adjust scales of widgets based on an anchor size.

### DIFF
--- a/scene/gui/aspect_ratio_container.h
+++ b/scene/gui/aspect_ratio_container.h
@@ -58,6 +58,8 @@ private:
 	float ratio = 1.0;
 	float max_ratio = ratio;
 	bool use_max_ratio = false;
+	bool use_auto_size = false;
+	float auto_size_extent = 1080.0f;
 	StretchMode stretch_mode = STRETCH_FIT;
 	AlignMode alignment_horizontal = ALIGN_CENTER;
 	AlignMode alignment_vertical = ALIGN_CENTER;
@@ -70,7 +72,13 @@ public:
 	float get_max_ratio() const { return max_ratio; }
 
 	void set_use_max_ratio(bool p_use_max_ratio);
-	float get_use_max_ratio() const { return use_max_ratio; }
+	bool get_use_max_ratio() const { return use_max_ratio; }
+
+	void set_use_auto_size(bool p_use_auto_size);
+	bool get_use_auto_size() const { return use_auto_size; }
+
+	void set_auto_size_extent(float p_auto_size_extents);
+	float get_auto_size_extent() const { return auto_size_extent; }
 
 	void set_stretch_mode(StretchMode p_mode);
 	StretchMode get_stretch_mode() const { return stretch_mode; }

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -328,7 +328,7 @@ void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	{
 		List<StringName> names;
-		theme->get_color_list(get_class_name(), &names);
+		theme->get_color_list(get_theme_lookup_name(), &names);
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			uint32_t hint = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 			if (data.color_override.has(E->get())) {
@@ -340,7 +340,7 @@ void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 	{
 		List<StringName> names;
-		theme->get_constant_list(get_class_name(), &names);
+		theme->get_constant_list(get_theme_lookup_name(), &names);
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			uint32_t hint = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 			if (data.constant_override.has(E->get())) {
@@ -352,7 +352,7 @@ void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 	{
 		List<StringName> names;
-		theme->get_font_list(get_class_name(), &names);
+		theme->get_font_list(get_theme_lookup_name(), &names);
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			uint32_t hint = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 			if (data.font_override.has(E->get())) {
@@ -364,7 +364,7 @@ void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 	{
 		List<StringName> names;
-		theme->get_icon_list(get_class_name(), &names);
+		theme->get_icon_list(get_theme_lookup_name(), &names);
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			uint32_t hint = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 			if (data.icon_override.has(E->get())) {
@@ -376,7 +376,7 @@ void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 	{
 		List<StringName> names;
-		theme->get_shader_list(get_class_name(), &names);
+		theme->get_shader_list(get_theme_lookup_name(), &names);
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			uint32_t hint = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 			if (data.shader_override.has(E->get())) {
@@ -388,7 +388,7 @@ void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 	{
 		List<StringName> names;
-		theme->get_stylebox_list(get_class_name(), &names);
+		theme->get_stylebox_list(get_theme_lookup_name(), &names);
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			uint32_t hint = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 			if (data.style_override.has(E->get())) {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -256,6 +256,8 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
+	virtual const StringName &get_theme_lookup_name() const { return get_class_name(); }
+
 	void _notification(int p_notification);
 	static void _bind_methods();
 	virtual void _validate_property(PropertyInfo &property) const;

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -64,8 +64,6 @@ private:
 	int line_count;
 	bool uppercase;
 
-	int get_longest_line_width() const;
-
 	struct WordCache {
 		enum {
 			CHAR_NEWLINE = -1,
@@ -97,6 +95,7 @@ private:
 	int max_lines_visible;
 
 protected:
+	int get_longest_line_width() const;
 	void _notification(int p_what);
 
 	static void _bind_methods();


### PR DESCRIPTION
This addition adds a flag on the aspect ratio box which handles automatically resizing the contents when it hits a minimum size.  This allows wrapping widgets in the box and having them automatically handle their sizing without having to redo all the underlying positioning.

https://www.loom.com/share/09b047090bc8406c81ad0cc98dad7612
^ Video of it in action when wrapping a complex widget.