### PR TITLE
Fix remote transform not applying rotation globally

### DIFF
--- a/scene/3d/remote_transform.cpp
+++ b/scene/3d/remote_transform.cpp
@@ -68,7 +68,7 @@ void RemoteTransform::_update_remote() {
 			Transform our_trans = get_global_transform();
 
 			if (update_remote_rotation) {
-				n->set_rotation(our_trans.basis.get_rotation());
+				n->set_global_rotation(our_trans.basis.get_rotation());
 			}
 
 			if (update_remote_scale) {


### PR DESCRIPTION
We were running into an issue where remote transforms were not being applied properly when not using all properties at once.

Issue is reported here: https://github.com/godotengine/godot/issues/56178

Footage of before:

https://github.com/pahdolabs/godot/assets/12591253/ed29655e-4d09-43d9-b6e2-84fc4f6525e5

Loom of after:
https://www.loom.com/share/0faab4a53e13499885db329de6530279