### PR TITLE
Move function params to ZoneText

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -741,8 +741,11 @@ static void _test_call_error(const StringName &p_func, const Variant::CallError 
 
 void Object::call_multilevel(const StringName &p_method, const Variant **p_args, int p_argcount) {
 	ZoneScoped;
-	CharString c = Profiler::stringify_method(p_method, p_args, p_argcount);
-	ZoneName(c.ptr(), c.size());
+	const String class_name = get_class();
+	const CharString call_details = Profiler::stringify_method(class_name, p_method, p_args, p_argcount);
+	const CharString method_name = String(p_method).utf8();
+	ZoneName(method_name.ptr(), method_name.size());
+	ZoneText(call_details.ptr(), call_details.size());
 
 	if (p_method == CoreStringNames::get_singleton()->_free) {
 #ifdef DEBUG_ENABLED
@@ -871,8 +874,13 @@ void Object::call_multilevel(const StringName &p_name, VARIANT_ARG_DECLARE) {
 
 Variant Object::call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error) {
 	ZoneScoped;
-	CharString c = Profiler::stringify_method(p_method, p_args, p_argcount);
-	ZoneName(c.ptr(), c.size());
+	// TODO: Add methods to StringName and Object to return CharStrings.
+	// TODO: Modify stringify_method to accept CharStrings as input.
+	const String class_name = get_class();
+	const CharString call_details = Profiler::stringify_method(class_name, p_method, p_args, p_argcount);
+	const CharString method_name = String(p_method).utf8();
+	ZoneName(method_name.ptr(), method_name.size());
+	ZoneText(call_details.ptr(), call_details.size());
 
 	r_error.error = Variant::CallError::CALL_OK;
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1245,8 +1245,11 @@ void Variant::call_ptr(const StringName &p_method, const Variant **p_args, int p
 		_VariantCall::FuncData &funcdata = E->get();
 		{
 			ZoneScoped;
-			CharString c = Profiler::stringify_method(p_method, p_args, p_argcount);
-			ZoneName(c.ptr(), c.size());
+			const String class_name = get_type_name(get_type());
+			const CharString call_details = Profiler::stringify_method(class_name, p_method, p_args, p_argcount);
+			const CharString method_name = String(p_method).utf8();
+			ZoneName(method_name.ptr(), method_name.size());
+			ZoneText(call_details.ptr(), call_details.size());
 			funcdata.call(ret, *this, p_args, p_argcount, r_error);
 		}
 	}


### PR DESCRIPTION
When the result of `stringify_method` is passed to ZoneName, it means that almost every call to a given method has a different name. To use Tracy effectively, we need to be able to group zones by name, so the ZoneName is restricted the method name, and the full method info is placed into ZoneText.

Based on a change to `stringify_method` in the `godot_tracy` module, the object's registered class name is also added so it's easier to find the context of the call.