### PR TITLE
Add FrameMark to other platforms

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -37,6 +37,7 @@
 #include "dir_access_osx.h"
 #include "drivers/gles2/rasterizer_gles2.h"
 #include "drivers/gles3/rasterizer_gles3.h"
+#include "godot_tracy/profiler.h"
 #include "main/main.h"
 #include "servers/visual/visual_server_raster.h"
 
@@ -3426,6 +3427,8 @@ void OS_OSX::run() {
 
 	while (!force_quit && !quit) {
 		@try {
+			FrameMark;
+			ZoneScoped;
 			process_events(); // get rid of pending events
 			joypad_osx->process_joypads();
 

--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -33,6 +33,7 @@
 #include "core/print_string.h"
 #include "drivers/dummy/rasterizer_dummy.h"
 #include "drivers/dummy/texture_loader_dummy.h"
+#include "godot_tracy/profiler.h"
 #include "servers/visual/visual_server_raster.h"
 
 #include "main/main.h"
@@ -199,6 +200,8 @@ void OS_Server::run() {
 	main_loop->init();
 
 	while (!force_quit) {
+		FrameMark;
+		ZoneScoped;
 		if (Main::iteration())
 			break;
 	};

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -38,6 +38,7 @@
 #include "drivers/unix/net_socket_posix.h"
 #include "drivers/windows/dir_access_windows.h"
 #include "drivers/windows/file_access_windows.h"
+#include "godot_tracy/profiler.h"
 #include "joypad_windows.h"
 #include "lang_table.h"
 #include "main/main.h"
@@ -3539,6 +3540,8 @@ void OS_Windows::run() {
 	main_loop->init();
 
 	while (!force_quit) {
+		FrameMark;
+		ZoneScoped;
 		process_events(); // get rid of pending events
 		if (Main::iteration())
 			break;


### PR DESCRIPTION
The FrameMark that tells Tracy about the boundary between frames, was only added to the OS_X11::run function. This PR adds it to the other platforms that we're likely to run Tracy on, unlocking a powerful source of insights, as below where a specific RPC took up 13ms

![image](https://github.com/pahdolabs/godot/assets/109116583/c47d7ebc-ebec-445b-a289-f354c751324f)
