### PR TITLE
Removing dependency on INT_MAX define not always available on linux in multiplayer_api.h

### DIFF
--- a/core/io/multiplayer_api.h
+++ b/core/io/multiplayer_api.h
@@ -168,7 +168,7 @@ public:
 	MultiplayerAPI();
 	~MultiplayerAPI();
 
-	static const int LOCAL_CLIENT_SENDER_ID = INT_MAX - 1;
+	static const int LOCAL_CLIENT_SENDER_ID = 2147483646; // INT_MAX - 1
 };
 
 VARIANT_ENUM_CAST(MultiplayerAPI::RPCMode);

--- a/core/io/multiplayer_api.h
+++ b/core/io/multiplayer_api.h
@@ -168,7 +168,7 @@ public:
 	MultiplayerAPI();
 	~MultiplayerAPI();
 
-	static const int LOCAL_CLIENT_SENDER_ID = 2147483646; // INT_MAX - 1
+	static const int LOCAL_CLIENT_SENDER_ID = std::numeric_limits<std::int32_t>::max() - 1;
 };
 
 VARIANT_ENUM_CAST(MultiplayerAPI::RPCMode);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -632,8 +632,10 @@ void Node::srpc(const StringName &p_method, VARIANT_ARG_DECLARE) {
 
 
 	Ref<MultiplayerAPI> api = get_multiplayer();
-	int sender = api->get_network_unique_id();
-	if (sender <= 0) {
+	int sender;
+	if (api->get_network_peer().is_null() == false) {
+		sender = api->get_network_unique_id();
+	} else {
 		sender = MultiplayerAPI::LOCAL_CLIENT_SENDER_ID;
 	}
 	int temp_id = api->get_rpc_sender_id();


### PR DESCRIPTION
Removing dependency on INT_MAX define not always available on linux in multiplayer_api.h
Removing unecessary warnings in rpc methods with sender ids.