### PR TITLE
Adding null guard checks to prevent crashes in srpc in multiplayer disconnect circumstances.

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -607,7 +607,7 @@ void Node::rset_config(const StringName &p_property, MultiplayerAPI::RPCMode p_m
 
 /***** RPC FUNCTIONS ********/
 void Node::srpc(const StringName &p_method, VARIANT_ARG_DECLARE) {
-	if (get_tree()->has_network_peer()) {
+	if (get_tree() != nullptr && get_tree()->get_multiplayer().is_null() == false && get_tree()->has_network_peer()) {
 		rpc(p_method, VARIANT_ARG_PASS);
 		return;
 	}

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -638,7 +638,10 @@ void Node::srpc(const StringName &p_method, VARIANT_ARG_DECLARE) {
 	} else {
 		sender = MultiplayerAPI::LOCAL_CLIENT_SENDER_ID;
 	}
-	int temp_id = api->get_rpc_sender_id();
+	int temp_id = 0;
+	if (api.is_null() == false) {
+		temp_id = api->get_rpc_sender_id();
+	}
 	get_multiplayer()->set_rpc_sender_id(sender);
 	if (call_native) {
 		call(p_method, argptr, argc, ce);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -633,7 +633,7 @@ void Node::srpc(const StringName &p_method, VARIANT_ARG_DECLARE) {
 
 	Ref<MultiplayerAPI> api = get_multiplayer();
 	int sender;
-	if (api->get_network_peer().is_null() == false) {
+	if (api.is_null() == false && api->get_network_peer().is_null() == false) {
 		sender = api->get_network_unique_id();
 	} else {
 		sender = MultiplayerAPI::LOCAL_CLIENT_SENDER_ID;


### PR DESCRIPTION
There was another couple places where nulls needed to be checked in the srpc flow.