### PR TITLE
More Tracy annotations, focused on instancing

### DIFF
--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -35,6 +35,7 @@
 #include "core/os/file_access.h"
 #include "core/os/os.h"
 #include "core/script_language.h"
+#include "godot_tracy/profiler.h"
 #include "scene/main/node.h" //only so casting works
 
 #include <stdio.h>
@@ -143,6 +144,7 @@ void Resource::reload_from_file() {
 }
 
 Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, Map<Ref<Resource>, Ref<Resource>> &remap_cache) {
+	ZoneScoped;
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
 
@@ -178,6 +180,7 @@ Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, Map<Ref<Res
 }
 
 void Resource::configure_for_local_scene(Node *p_for_scene, Map<Ref<Resource>, Ref<Resource>> &remap_cache) {
+	ZoneScoped;
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -91,6 +91,7 @@ void GDScript::_clear_pending_func_states() {
 }
 
 GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_isref, Variant::CallError &r_error) {
+	ZoneScoped;
 	/* STEP 1, CREATE */
 
 	GDScriptInstance *instance = memnew(GDScriptInstance);
@@ -133,6 +134,7 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 }
 
 Variant GDScript::_new(const Variant **p_args, int p_argcount, Variant::CallError &r_error) {
+	ZoneScoped;
 	/* STEP 1, CREATE */
 
 	if (!valid) {
@@ -1100,6 +1102,7 @@ Variant::Type GDScriptInstance::get_property_type(const StringName &p_name, bool
 
 void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 	// exported members, not done yet!
+	ZoneScoped;
 
 	const GDScript *sptr = script.ptr();
 	List<PropertyInfo> props;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -33,6 +33,7 @@
 #include "core/engine.h"
 #include "core/project_settings.h"
 #include "core/version.h"
+#include "godot_tracy/profiler.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_settings.h"
@@ -180,6 +181,7 @@ Variant ShaderMaterial::property_get_revert(const String &p_name) {
 }
 
 void ShaderMaterial::set_shader(const Ref<Shader> &p_shader) {
+	ZoneScoped;
 	// Only connect/disconnect the signal when running in the editor.
 	// This can be a slow operation, and `_change_notify()` (which is called by `_shader_changed()`)
 	// does nothing in non-editor builds anyway. See GH-34741 for details.
@@ -208,6 +210,7 @@ Ref<Shader> ShaderMaterial::get_shader() const {
 }
 
 void ShaderMaterial::set_shader_param(const StringName &p_param, const Variant &p_value) {
+	ZoneScoped;
 	VS::get_singleton()->material_set_param(_get_material(), p_param, p_value);
 }
 
@@ -216,6 +219,7 @@ Variant ShaderMaterial::get_shader_param(const StringName &p_param) const {
 }
 
 void ShaderMaterial::_shader_changed() {
+	ZoneScoped;
 	_change_notify(); //update all properties
 }
 
@@ -359,6 +363,7 @@ void SpatialMaterial::finish_shaders() {
 }
 
 void SpatialMaterial::_update_shader() {
+	ZoneScoped;
 	dirty_materials->remove(&element);
 
 	MaterialKey mk = _compute_key();
@@ -384,6 +389,8 @@ void SpatialMaterial::_update_shader() {
 	}
 
 	//must create a shader!
+	const char zone_text[] = "Creating a shader";
+	ZoneText(zone_text, sizeof(zone_text));
 
 	// Add a comment to describe the shader origin (useful when converting to ShaderMaterial).
 	String code = "// NOTE: Shader automatically converted from " VERSION_NAME " " VERSION_FULL_CONFIG "'s SpatialMaterial.\n\n";
@@ -1382,6 +1389,7 @@ bool SpatialMaterial::get_feature(Feature p_feature) const {
 }
 
 void SpatialMaterial::set_texture(TextureParam p_param, const Ref<Texture> &p_texture) {
+	ZoneScoped;
 	ERR_FAIL_INDEX(p_param, TEXTURE_MAX);
 	textures[p_param] = p_texture;
 	RID rid = p_texture.is_valid() ? p_texture->get_rid() : RID();

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -29,7 +29,9 @@
 /*************************************************************************/
 
 #include "shader.h"
+
 #include "core/os/file_access.h"
+#include "godot_tracy/profiler.h"
 #include "scene/scene_string_names.h"
 #include "servers/visual/shader_language.h"
 #include "servers/visual_server.h"
@@ -40,6 +42,7 @@ Shader::Mode Shader::get_mode() const {
 }
 
 void Shader::set_code(const String &p_code) {
+	ZoneScoped;
 	String type = ShaderLanguage::get_shader_type(p_code);
 
 	if (type == "canvas_item") {


### PR DESCRIPTION
ZoneNamedN is used in one spot so that it's easier to tell what the ZoneTextV calls further down correspond to. Otherwise it's not necessary.