### PR TITLE
Add sentry context to resource loader

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -37,6 +37,8 @@
 #include "core/project_settings.h"
 #include "core/version.h"
 
+#include "sentry/sentry.h"
+
 //#define print_bl(m_what) print_line(m_what)
 #define print_bl(m_what) (void)(m_what)
 
@@ -595,6 +597,13 @@ Error ResourceInteractiveLoaderBinary::poll() {
 	}
 
 	int s = stage;
+	
+	Dictionary context_data;
+	context_data["polling"] = res_path;
+	context_data["type"] = "binary";
+	context_data["stage"] = s;
+	
+	Sentry::singleton()->add_context("Resource.Loader", context_data);
 
 	if (s < external_resources.size()) {
 		String path = external_resources[s].path;

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -199,6 +199,9 @@ RES ResourceFormatLoader::load(const String &p_path, const String &p_original_pa
 			}
 			
 			Dictionary context_data;
+			context_data["polling"] = p_path;
+			context_data["type"] = "Loader";
+			context_data["stage"] = -1;
 			Sentry::singleton()->add_context("Resource.Loader", context_data);
 			
 			return ril->get_resource();

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -38,6 +38,7 @@
 #include "core/project_settings.h"
 #include "core/translation.h"
 #include "core/variant_parser.h"
+#include "sentry/sentry.h"
 
 Ref<ResourceFormatLoader> ResourceLoader::loader[ResourceLoader::MAX_LOADERS];
 
@@ -196,6 +197,10 @@ RES ResourceFormatLoader::load(const String &p_path, const String &p_original_pa
 			if (r_error) {
 				*r_error = OK;
 			}
+			
+			Dictionary context_data;
+			Sentry::singleton()->add_context("Resource.Loader", context_data);
+			
 			return ril->get_resource();
 		}
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -41,6 +41,8 @@
 #include "core/os/dir_access.h"
 #include "core/version.h"
 
+#include "sentry/sentry.h"
+
 #define _printerr() ERR_PRINT(String(res_path + ":" + itos(lines) + " - Parse Error: " + error_text).utf8().get_data());
 
 ///
@@ -367,6 +369,13 @@ Error ResourceInteractiveLoaderText::poll() {
 	if (error != OK) {
 		return error;
 	}
+	
+	Dictionary context_data;
+	context_data["polling"] = res_path;
+	context_data["type"] = "text";
+	context_data["stage"] = get_stage();
+	
+	Sentry::singleton()->add_context("Resource.Loader", context_data);
 
 	if (next_tag.name == "ext_resource") {
 		if (!next_tag.fields.has("path")) {


### PR DESCRIPTION
Adds sentry context to ResourceLoader so we have a deeper visibility into what is being loaded, if the loader crashes.